### PR TITLE
testing around with types

### DIFF
--- a/cloud_webserver_v2/internal/background/mcap_jobs.go
+++ b/cloud_webserver_v2/internal/background/mcap_jobs.go
@@ -241,7 +241,7 @@ func (p *PostProcessMCAPUploadJob) readMCAPMessages(ctx context.Context, job *Fi
 
 			decodedMessage, err := mcapUtils.GetDecodedMessage(schema, message)
 			if err != nil {
-				log.Printf("could not decode message: %v", err)
+				log.Printf("error decoding message: %v", err)
 				continue
 			}
 


### PR DESCRIPTION
# Features
- we can now store strings, floats, ints, bools basically any type of data into our h5 files.
- we can now store repeated types and enums as well
- works w json values now

## Important
This is the way our data was stored before
`[ [timestamp, data] ,[timestamp, data]]`
This is now
`[ {timestamp: x, data: y},{timestamp: x, data: y}]`

### How each signal in the mat files look WITH OLD PARSER
- With many chunks <img width="200" alt="Screenshot 2025-03-04 at 1 07 05 AM" src="https://github.com/user-attachments/assets/9190e138-1251-48c3-bc22-1f474266d2d5" />
- With one chunk <img width="200" alt="Screenshot 2025-03-04 at 1 08 24 AM" src="https://github.com/user-attachments/assets/83838e83-838e-4085-9204-cf5f932bfe62" />
- This is how each cell array looks
<img width="300" alt="Screenshot 2025-03-04 at 1 17 32 AM" src="https://github.com/user-attachments/assets/ebaabd44-ef3e-40dd-b963-8689b214b166" />

###  How each signal in the mat files look WITH NEW PARSER
*I made a parser that parses the h5 into tables --> down below is the zip file
<img width="300" alt="Screenshot 2025-03-04 at 5 00 31 AM" src="https://github.com/user-attachments/assets/f7581444-99b2-4259-851f-1585352df3c0" />
<img width="300" alt="Screenshot 2025-03-04 at 5 00 39 AM" src="https://github.com/user-attachments/assets/4769cff3-ede3-4d94-ac58-50aaa95a0f05" />

[tables.mat.zip](https://github.com/user-attachments/files/19065546/tables.mat.zip)

### How strings look (dial state _was_ a string in this mcap file)
<img width="300" alt="Screenshot 2025-03-04 at 1 09 57 AM" src="https://github.com/user-attachments/assets/c036962e-f9c2-4ebd-a714-1ed40bc23bcf" />

### How enums look (instead of the int32value --> replaced by the name of the enum value)
<img width="300" alt="Screenshot 2025-03-04 at 1 10 44 AM" src="https://github.com/user-attachments/assets/d3989104-46c2-40ab-be04-9a9eca4667b1" />

### How repeated types look
readings_pa was a repeated type
<img width="300" alt="Screenshot 2025-03-04 at 1 30 29 AM" src="https://github.com/user-attachments/assets/2e31dc8c-9887-44ab-8315-24792c833f89" />

### How json values look
this is using Ben's test mcap file w json

<img width="738" alt="Screenshot 2025-03-05 at 2 07 32 AM" src="https://github.com/user-attachments/assets/95271020-08c1-45b2-a5e2-913e75450a42" />



Ben's test mcap file down below!

[benmcap.mcap.zip](https://github.com/user-attachments/files/19084103/benmcap.mcap.zip)



### Proof that it processes in Docker
<img width="300" alt="Screenshot 2025-03-04 at 1 11 35 AM" src="https://github.com/user-attachments/assets/98a8d950-8bf0-447a-b641-4ea9c2111c1b" />

#### FILE UPLOADED USING MY LOGIC
_copy this url down below to see for yourself the product_
https://hytech-racing.github.io/query-frontend/?id=67c6976759922302eb65fb25
**notes to consider for the file above** : some string signals in this mcap file like _torque_controller_mux_status_ do not have ANY data (look at foxglove)


#### Side note: Will people want the ints & bools to be turned into floats?