### PR TITLE
HT08->HT09

### DIFF
--- a/cloud_webserver_v2/internal/background/mcap_jobs.go
+++ b/cloud_webserver_v2/internal/background/mcap_jobs.go
@@ -183,7 +183,7 @@ func (p *PostProcessMCAPUploadJob) Process(fp *FileProcessor, job *FileJob) erro
 
 	vehicleRunModel := &models.VehicleRunModel{
 		Date:         job.Date,
-		CarModel:     "HT08",
+		CarModel:     "HT09",
 		McapFiles:    mcapFiles,
 		MatFiles:     matFiles,
 		ContentFiles: contentFiles,


### PR DESCRIPTION
Uploaded files automatically get assigned HT08

considering HT08 does not exist anymore, it will be time efficient to auto-assign to HT09 since testing should ramp up