### PR TITLE
refactor(messaging): made routing integrated with the publisher

### DIFF
--- a/cloud_webserver_v2/internal/background/file_processor.go
+++ b/cloud_webserver_v2/internal/background/file_processor.go
@@ -29,7 +29,7 @@ const (
 // The Process function contains logic to execute a FileJob.
 // A job uses the Process function to perform its task.
 type FileJobProcessor interface {
-	Process(fp *FileProcessor, job *FileJob) error
+	ProcessFileJob(fp *FileProcessor, job *FileJob) error
 }
 
 // A FileProcessor handles FileJobs in a queue manner.
@@ -213,7 +213,7 @@ func (fp *FileProcessor) jobQueueListener(ctx context.Context) {
 		case <-fp.stopChan:
 			return
 		case job := <-fp.fileQueueChan:
-			if err := job.Processor.Process(fp, job); err != nil {
+			if err := job.Processor.ProcessFileJob(fp, job); err != nil {
 				log.Printf("Failed to process file %s: %v", job.Filename, err)
 				fp.updateJobStatus(job, StatusFailed)
 				// TODO: Add job status to database
@@ -227,6 +227,7 @@ func (fp *FileProcessor) updateJobStatus(job *FileJob, status string) {
 	fp.mu.Lock()
 	defer fp.mu.Unlock()
 
+	log.Printf("Updating job %s status to %s", job.ID, status)
 	job.Status = status
 	job.UpdatedAt = time.Now()
 }
@@ -235,6 +236,7 @@ func (fp *FileProcessor) updateJobStatus(job *FileJob, status string) {
 func (fp *FileProcessor) setCurrentlyProcessing(flag bool) {
 	fp.mu.Lock()
 	defer fp.mu.Unlock()
+	log.Printf("Updating file processor currently processing to %v", flag)
 	fp.activelyProcessing = flag
 }
 

--- a/cloud_webserver_v2/internal/messaging/subscribers.go
+++ b/cloud_webserver_v2/internal/messaging/subscribers.go
@@ -248,6 +248,7 @@ func CreateRawMatlabFile(id int, subscriberName string, ch <-chan SubscribedMess
 	var filePath string
 	for msg := range ch {
 		if msg.GetContent().Topic == EOF {
+			break
 		} else if msg.GetContent().Topic == INIT {
 			if name, exists := msg.GetContent().Data["file_name"]; exists {
 				fileName = name.(string)


### PR DESCRIPTION
Makes a router a first class citizen within the messaging package because most cases will want to route their messages automatically.